### PR TITLE
fix(format): correct prompt

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,5 @@ fn main() {
     buffer = cc_description(&buffer);
     buffer = cc_body(&buffer);
 
-    println!("{}", buffer);
-
     commit(&buffer);
 }

--- a/src/modules/format.rs
+++ b/src/modules/format.rs
@@ -31,7 +31,7 @@ pub fn cc_scope(prev: &str) -> String {
 
 pub fn cc_breaking_change(prev: &str) -> String {
     print!("\x1B[1A\x1B[2K");
-    print!("{} <- has breaking change? y/N", prev);
+    print!("{} <- has breaking change? y/N ", prev);
     io::stdout().flush().unwrap();
 
     let mut buffer = String::new();


### PR DESCRIPTION
## What's been changed?

- Add trailing space to breaking change prompt
- Remove debug `println`
