### PR TITLE
feat: add breaking change footer

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,7 @@ fn main() {
     buffer = cc_body(&buffer);
     buffer = cc_footer(&buffer);
 
-    if cc_confirm() {
-        commit(&buffer);
-    }
+    cc_confirm();
+
+    commit(&buffer);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,9 @@ fn main() {
     let mut buffer = String::from(cc_type);
 
     buffer = cc_scope(&buffer);
-    buffer = cc_breaking_change(&buffer);
+
+    let (breaking_change, has_breaking_change) = cc_breaking_change(&buffer);
+    buffer = breaking_change;
 
     match cc_description(&buffer) {
         Ok(new_buffer) => buffer = new_buffer,
@@ -30,9 +32,9 @@ fn main() {
     };
 
     buffer = cc_body(&buffer);
-    buffer = cc_footer(&buffer);
+
+    buffer = cc_footer(&buffer, has_breaking_change);
 
     cc_confirm();
-
     commit(&buffer);
 }

--- a/src/modules/format.rs
+++ b/src/modules/format.rs
@@ -33,11 +33,11 @@ fn prompt(r#type: PromptType, prev: &str) -> String {
         }
         PromptType::Body => {
             println!("");
-            print!("[body] ");
+            print!(">> ");
         }
         PromptType::Footer => {
             println!("");
-            print!("[footer] ");
+            print!(">> ");
         }
     }
     io::stdout().flush().unwrap();
@@ -123,18 +123,12 @@ pub fn cc_footer(prev: &str) -> String {
     format!("{}\n\n{}", prev, footer)
 }
 
-pub fn cc_confirm() -> bool {
+pub fn cc_confirm() {
     println!("\n--------------------");
-    print!("Ready to commit? y/N ");
+    print!("Ready to commit? [Enter] ");
     io::stdout().flush().unwrap();
 
     let mut buffer = String::new();
     io::stdin().read_line(&mut buffer).unwrap();
     println!("");
-
-    if buffer.trim().to_lowercase().as_str() == "y" {
-        return true;
-    };
-
-    false
 }


### PR DESCRIPTION
## What's been changed?

- Add breaking change footer prompt and formatter
- Refactor `cc_confirm` to use return as confirmation, to cancel, use interrupt 
