### PR TITLE
fix: update symlink on formula

### DIFF
--- a/Formula/ccrs.rb
+++ b/Formula/ccrs.rb
@@ -6,7 +6,7 @@ class Ccrs < Formula
 
   def install
     bin.install "ccrs"
-    bin.install_symlink "ccrs" => "cc"
+    bin.install_symlink "ccrs" => "crs"
   end
 end
 


### PR DESCRIPTION
## What's been changed?

- Update symlink from `cc` to `crs` as `cc` is for `clang`
