### PR TITLE
chore: bump checksum to v0.2.3

### DIFF
--- a/Formula/ccrs.rb
+++ b/Formula/ccrs.rb
@@ -2,7 +2,7 @@ class Ccrs < Formula
   desc "A CLI tool for creating conventional commits"
   homepage "https://github.com/tofuuudon/ccrs"
   url "https://github.com/tofuuudon/ccrs/releases/download/v0.2.2/ccrs.tar.gz"
-  sha256 "aff008587f1f0760580182d99a4df970dfc4e4ce81d45dccdc7fff75301e5e30"
+  sha256 "166108f48615cab16b6e4be4ae7d20da9eca44b9d70a51ac6f54a264f5fdeecb"
 
   def install
     bin.install "ccrs"


### PR DESCRIPTION
## What's been changed?

- Update checksum for `v0.2.3`
